### PR TITLE
Add option to disable 2x quality module effect

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,5 +1,7 @@
-for _, quality in pairs(data.raw.quality) do
-    if quality.next_probability then
-        quality.next_probability = quality.next_probability * 2
-    end
+if settings.startup["double-quality-module-effects"].value then
+	for _, quality in pairs(data.raw.quality) do
+		if quality.next_probability then
+			quality.next_probability = quality.next_probability * 2
+		end
+	end
 end

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -9,3 +9,9 @@ promethium-science-pack=Used to research powerful infinite technologies, which w
 
 [technology-name]
 infinite-quality=__1__ quality
+
+[mod-setting-name]
+double-quality-module-effects=Double all effects of modules regarding quality?
+
+[mod-setting-description]
+double-quality-module-effects=Quality modules become 2%/4%/5%, speed module penalties become -2%/-4%/-5%

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,8 @@
+data:extend({
+    {
+        type = "bool-setting",
+        name = "double-quality-module-effects",
+        setting_type = "startup",
+        default_value = true
+    }
+})


### PR DESCRIPTION
It's appreciated but the mod page doesn't actually... say that it does this?? so it can ruin the balance for some people, this is more of an "it's there if you want it" kind of thing